### PR TITLE
optimize performance of sync loop

### DIFF
--- a/lib/syn_supervisor.ex
+++ b/lib/syn_supervisor.ex
@@ -1094,19 +1094,17 @@ defmodule SynSupervisor do
   end
 
   defp child_running?(%{children: children}, child_id) do
-    children
-    |> Map.filter(fn
-      {_pid, {^child_id, _, _, _, _, _}} ->
-        true
+    child =
+      children
+      |> Enum.find(fn
+        {_pid, {^child_id, _, _, _, _, _}} ->
+          true
 
-      _ ->
-        false
-    end)
-    |> map_size()
-    |> case do
-      0 -> false
-      _ -> true
-    end
+        _ ->
+          false
+      end)
+
+    not is_nil(child)
   end
 
   defp maybe_stop_child(%Child{} = c, assigned_node, _assigned_sup, state) do

--- a/test/syn_supervisor_test.exs
+++ b/test/syn_supervisor_test.exs
@@ -88,7 +88,8 @@ defmodule SynSupervisorTest do
                 %{
                   strategy: :one_for_one,
                   scope: scope,
-                  sync_interval: 3_000,
+                  sync_interval: 5 * 60_000,
+                  sync_delay_on_topology_change: 5_000,
                   intensity: 3,
                   period: 5,
                   max_children: :infinity,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,4 +3,7 @@
 Application.ensure_all_started(:syn)
 Application.ensure_all_started(:libring)
 
+require Logger
+Logger.configure(level: :warning)
+
 ExUnit.start(capture_log: true)

--- a/test_helpers/test_app/lib/test_app/application.ex
+++ b/test_helpers/test_app/lib/test_app/application.ex
@@ -6,7 +6,11 @@ defmodule TestApp.Application do
   @impl true
   def start(_type, _args) do
     children = [
-      {SynSupervisor, name: TestApp.DistributedSupervisor, scope: :test, sync_interval: 5}
+      {SynSupervisor,
+       name: TestApp.DistributedSupervisor,
+       scope: :test,
+       sync_interval: 5,
+       sync_delay_on_topology_change: 5}
     ]
 
     opts = [strategy: :one_for_one, name: TestApp.Supervisor]


### PR DESCRIPTION
- use different scopes for children, specs and nodes to avoid filtering/mapping when retrieving syn's group names
- use a larger interval for the sync loop, but monitor nodes to respond quicker in case the cluster topology changes